### PR TITLE
fix: update for using on bare metal without GHA

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - name: Get semver-tags
         run: |
-          wget -c https://github.com/catalystcommunity/semver-tags/releases/download/v0.3.2/semver-tags.tar.gz -O - | tar -xz
+          wget -c https://github.com/catalystcommunity/semver-tags/releases/download/v0.3.3/semver-tags.tar.gz -O - | tar -xz
       - name: Semver Tags Run
         id: semver-tags
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           git config --global user.email "<catalyst-community@todandlorna.com>"
       - name: Get semver-tags
         run: |
-          wget -c https://github.com/catalystcommunity/semver-tags/releases/download/v0.3.2/semver-tags.tar.gz -O - | tar -xz
+          wget -c https://github.com/catalystcommunity/semver-tags/releases/download/v0.3.3/semver-tags.tar.gz -O - | tar -xz
       - name: Semver Tags Run
         id: semver-tags
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ LABEL maintainer="Catalyst Community <catalyst-community@todandlorna.com>"
 
 WORKDIR /workspace
 ARG TARGETPLATFORM=amd64
-ARG RUNNER_VERSION=2.308.0
+ARG RUNNER_VERSION=2.321.0
 ARG DOCKER_CHANNEL=stable
-ARG DOCKER_VERSION=24.0.5
+ARG DOCKER_VERSION=27.3.1
 ARG DUMB_INIT_VERSION=1.2.5
-ARG GO_VERSION=1.21.4
+ARG GO_VERSION=1.23.3
 
 # Get all the tools in and up to date
 ENV DEBIAN_FRONTEND=noninteractive
@@ -59,8 +59,8 @@ RUN apt update -y \
 #RUN pip3 install --upgrade --break-system-packages pip
 RUN pip3 install --break-system-packages setuptools watchdog poetry yq yamllint
 
-# Get all the node tooling in with 18.x
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+# Get all the node tooling in with 22.x
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get install -y nodejs
 
 RUN npm install -g yarn


### PR DESCRIPTION
Setting this up as a CI/CD runner for bare metal without Github Actions. This should just update some versions, specifically of Go and Node.